### PR TITLE
Fixing wrong default of zba_api_url (omit doesn't work)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,7 +163,7 @@
     ansible_httpapi_validate_certs: '{{ _zba_api_validate_certs }}'
     ansible_user: '{{ _zba_api_user }}'
     ansible_httpapi_pass: '{{ _zba_api_password | default(omit) }}'
-    zabbix_api_url: '{{ _zba_api_url | default(omit) }}'
+    zabbix_api_url: "{{ _zba_api_url | default('') }}"
 
     # HTTP basic auth variables
     http_login: '{{ _zba_http_login | default(omit) }}'


### PR DESCRIPTION
Setting `''` as default for `_zba_api_url` if it wasn't specified via `zba_api_url`, otherwise the execution would fail with a cryptic `404` error:
```
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py", line 107, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.zabbix.zabbix.plugins.modules.zabbix_host', init_globals=dict(_module_fqn='ansible_collections.zabbix.zabbix.plugins.modules.zabbix_host', _modlib_path=modlib_path),
  File "/usr/lib64/python3.9/runpy.py", line 225, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py", line 1187, in <module>
  File "/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py", line 1111, in main
  File "/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py", line 458, in __init__
  File "/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/module_utils/zabbix_api.py", line 54, in api_version
  File "/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible/module_utils/connection.py", line 200, in __rpc__
ansible.module_utils.connection.ConnectionError: HTTP Error 404: Not Found
fatal: [**redacted**]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-local-15e9iwwdnt/ansible-tmp-1698178150.1899276-35-163081140966943/AnsiballZ_zabbix_host.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.zabbix.zabbix.plugins.modules.zabbix_host', init_globals=dict(_module_fqn='ansible_collections.zabbix.zabbix.plugins.modules.zabbix_host', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.9/runpy.py\", line 225, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py\", line 1187, in <module>\n  File \"/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py\", line 1111, in main\n  File \"/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/modules/zabbix_host.py\", line 458, in __init__\n  File \"/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible_collections/zabbix/zabbix/plugins/module_utils/zabbix_api.py\", line 54, in api_version\n  File \"/tmp/ansible_zabbix.zabbix.zabbix_host_payload_436b8kyt/ansible_zabbix.zabbix.zabbix_host_payload.zip/ansible/module_utils/connection.py\", line 200, in __rpc__\nansible.module_utils.connection.ConnectionError: HTTP Error 404: Not Found\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```