### PR TITLE
feat: Adding option to disable plugins during dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ certified collections. If you don't own any subscriptions that provides this acc
 | `zba_api_port`                               | `443`                        | false    | port of the Zabbix server API                                                  |
 | `zba_api_use_ssl`                            | `true`                       | false    | whether to connect to the Zabbix API via `SSL`                                 |
 | `zba_api_validate_certs`                     | `true`                       | false    | whether to validate certificates when connecting to the API                    |
+| `zba_installation_disable_plugins`           | `[]`                         | false    | list of package manager plugins to disable when installing dependencies        |
 | `zba_no_cert`                                | `false`                      | false    | whether to not deploy certification validation (usually not needed to be set)  |
 | `zba_cert_path`                              | unset                        | false    | path to the certificate to extract issuer and subject from                     |
 | `zba_api_url`                                | unset                        | false    | use when Zabbix is served via a non-default path, e.g. `/zbx`                  |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
       ansible.builtin.package:
         name: '{{ _zba_required_packages }}'
         update_cache: true
+        disable_plugin: '{{ _zba_installation_disable_plugins | default(omit) }}'
 
     - name: 'Read certificate information'
       community.crypto.x509_certificate_info:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -50,4 +50,8 @@ _zba_http_login: '{{ zba_http_login | default(undef()) }}'
 
 # HTTP basic authentication password
 _zba_http_password: '{{ zba_http_password | default(undef()) }}'
+
+# disable plugins during installation of packages
+# note: works only for Red Hat based operating systems
+_zba_installation_disable_plugins: '{{ zba_installation_disable_plugins | default([]) }}'
 ...


### PR DESCRIPTION
Adding variable zba_installation_disable_plugins which takes a list of *DNF/YUM* plugins to disable during installing required packages. This helps in scenarios where all packages are excluded (see foreman-protector)